### PR TITLE
Exibir erro real do SEFAZ

### DIFF
--- a/woocommerce_nfe.php
+++ b/woocommerce_nfe.php
@@ -336,8 +336,14 @@ class WooCommerceNFe {
 				if (isset($response->log)){
 
 					if ($response->log->xMotivo){
-
-						$mensagem .= '<li>'.$response->log->xMotivo.'</li>';
+						
+						if(isset($response->log->aProt[0]->xMotivo)){
+							$error = $response->log->aProt[0]->xMotivo;
+						}else{
+							$error = $response->log->xMotivo;
+						}
+						
+						$mensagem .= '<li>'.$error.'</li>';
 
 					} else {
 


### PR DESCRIPTION
Alterado código para exibir erro de rejeição retornado do sefaz.
O erro foi definido através da array retornada simulando um NCM inválido: (array)[aProt][0]->xMotivo.
